### PR TITLE
Require ES5 + minimal Map<> instead of ES6

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,3 +1,5 @@
+/// <reference path='./references.d.ts' />
+
 import 'reflect-metadata';
 
 let dependencyStore: Map<any, DependencyDefinition> = new Map<any, DependencyDefinition>();

--- a/src/references.d.ts
+++ b/src/references.d.ts
@@ -1,0 +1,14 @@
+
+// Small part of the Map<> spec that goes beyond ES5 but is supported in IE11
+interface Map<K, V> {
+    has(key: K): boolean;
+    get(key: K): V;
+    set(key: K, value?: V): Map<K, V>;
+}
+
+interface MapConstructor {
+    new <K, V>(): Map<K, V>;
+    prototype: Map<any, any>;
+}
+
+declare var Map: MapConstructor;

--- a/test/mocks/classWithDecoratedDependency.mock.ts
+++ b/test/mocks/classWithDecoratedDependency.mock.ts
@@ -7,6 +7,7 @@ export const classWithDecoratedDependencyConstructorSpy: SinonSpy = spy();
 @Injectable
 export class ClassWithDecoratedDependency {
   constructor(@Inject(ProvidedDependencyToken) providedDependency: any) {
-    classWithDecoratedDependencyConstructorSpy(...arguments);
+    const args = arguments as any;
+    classWithDecoratedDependencyConstructorSpy(...args);
   }
 }

--- a/test/mocks/classWithDuplicateDependencies.mock.ts
+++ b/test/mocks/classWithDuplicateDependencies.mock.ts
@@ -7,6 +7,7 @@ export const classWithDuplicateDependenciesConstructorSpy: SinonSpy = spy();
 @Injectable
 export class ClassWithDuplicateDependencies {
   constructor(dependency1: DuplicateDependency, dependency2: DuplicateDependency) {
-    classWithDuplicateDependenciesConstructorSpy(...arguments);
+    const args = arguments as any;
+    classWithDuplicateDependenciesConstructorSpy(...args);
   }
 }

--- a/test/mocks/classWithNestedDependencies.mock.ts
+++ b/test/mocks/classWithNestedDependencies.mock.ts
@@ -7,6 +7,7 @@ export const classWithNestedDependenciesConstructorSpy: SinonSpy = spy();
 @Injectable
 export class ClassWithNestedDependencies {
   constructor(nestedDependencyParent: NestedDependencyParent) {
-    classWithNestedDependenciesConstructorSpy(...arguments);
+    const args = arguments as any;
+    classWithNestedDependenciesConstructorSpy(...args);
   }
 }

--- a/test/mocks/classWithNoDependency.mock.ts
+++ b/test/mocks/classWithNoDependency.mock.ts
@@ -6,6 +6,7 @@ export const classWithNoDependencyConstructorSpy: SinonSpy = spy();
 @Injectable
 export class ClassWithNoDependency {
   constructor() {
-    classWithNoDependencyConstructorSpy(...arguments);
+    const args = arguments as any;
+    classWithNoDependencyConstructorSpy(...args);
   }
 }

--- a/test/mocks/classWithTypedDependency.mock.ts
+++ b/test/mocks/classWithTypedDependency.mock.ts
@@ -7,6 +7,7 @@ export const classWithTypedDependencyConstructorSpy: SinonSpy = spy();
 @Injectable
 export class ClassWithTypedDependency {
   constructor(typedDependency: TypedDependency) {
-    classWithTypedDependencyConstructorSpy(...arguments);
+    const args = arguments as any;
+    classWithTypedDependencyConstructorSpy(...args);
   }
 }

--- a/test/mocks/classWithUndefinedDecoratedDependency.mock.ts
+++ b/test/mocks/classWithUndefinedDecoratedDependency.mock.ts
@@ -6,6 +6,7 @@ export const classWithUndefinedDecoratedDependencyConstructorSpy: SinonSpy = spy
 @Injectable
 export class ClassWithUndefinedDecoratedDependency {
   constructor(@Inject(undefined) providedDependency: any) {
-    classWithUndefinedDecoratedDependencyConstructorSpy(...arguments);
+    const args = arguments as any;
+    classWithUndefinedDecoratedDependencyConstructorSpy(...args);
   }
 }

--- a/test/mocks/duplicateDependency.mock.ts
+++ b/test/mocks/duplicateDependency.mock.ts
@@ -6,6 +6,7 @@ export const duplicateDependencyConstructorSpy: SinonSpy = spy();
 @Injectable
 export class DuplicateDependency {
   constructor() {
-    duplicateDependencyConstructorSpy(...arguments);
+    const args = arguments as any;
+    duplicateDependencyConstructorSpy(...args);
   }
 }

--- a/test/mocks/nestedDependencyChild.mock.ts
+++ b/test/mocks/nestedDependencyChild.mock.ts
@@ -6,6 +6,7 @@ export const nestedDependencyChildConstructorSpy: SinonSpy = spy();
 @Injectable
 export class NestedDependencyChild {
   constructor() {
-    nestedDependencyChildConstructorSpy(...arguments);
+    const args = arguments as any;
+    nestedDependencyChildConstructorSpy(...args);
   }
 }

--- a/test/mocks/nestedDependencyParent.mock.ts
+++ b/test/mocks/nestedDependencyParent.mock.ts
@@ -7,6 +7,7 @@ export const nestedDependencyParentConstructorSpy: SinonSpy = spy();
 @Injectable
 export class NestedDependencyParent {
   constructor(nestedDependencyChild: NestedDependencyChild) {
-    nestedDependencyParentConstructorSpy(...arguments);
+    const args = arguments as any;
+    nestedDependencyParentConstructorSpy(...args);
   }
 }

--- a/test/mocks/providedDependency.mock.ts
+++ b/test/mocks/providedDependency.mock.ts
@@ -1,6 +1,7 @@
 import { SinonStub, stub } from 'sinon';
 
-export const ProvidedDependencyToken = Symbol('providedDependency');
+// Would use Symbol() in ES6, string in ES5
+export const ProvidedDependencyToken = 'providedDependency';
 
 export const valueProvidedDependency = {
   name: 'providedDependency'

--- a/test/mocks/typedDependency.mock.ts
+++ b/test/mocks/typedDependency.mock.ts
@@ -6,6 +6,7 @@ export const typedDependencyConstructorSpy: SinonSpy = spy();
 @Injectable
 export class TypedDependency {
   constructor() {
-    typedDependencyConstructorSpy(...arguments);
+    const args = arguments as any;
+    typedDependencyConstructorSpy(...args);
   }
 }

--- a/test/tests.spec.ts
+++ b/test/tests.spec.ts
@@ -185,7 +185,7 @@ describe('DependencyInjection', function() {
         it('should throw an error with the name of the missing token', function() {
           expect(function() {
             bootstrap(ClassWithDecoratedDependency);
-          }).to.throw(Error, `Dependency 'Symbol(providedDependency)' could not be found.`);
+          }).to.throw(Error, `Dependency 'providedDependency' could not be found.`);
         });
       });
 
@@ -303,8 +303,8 @@ describe('DependencyInjection', function() {
       context('with no provide method', function() {
         it('should throw an error', function() {
           expect(function() {
-            provide(Symbol('should fail'), {});
-          }).to.throw(Error, `No provide method has been chosen, cannot provide dependency 'Symbol(should fail)'`);
+            provide('should fail', {});
+          }).to.throw(Error, `No provide method has been chosen, cannot provide dependency 'should fail'`);
         });
       });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es6",
+    "target": "es5",
     "declaration": true,
     "sourceMap": true,
     "noEmitOnError": true,


### PR DESCRIPTION
Here is a stab at IE11 support. A minor annoyance is that arguments is not an array type in ES5, so requires extra cast for splat.

This PR fixes #4